### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,9 @@ Follow the steps:
 - Download reinforcement metadata and set `reinforce.data_path` in `$CFG_FILE`.
 
 ```shell
-python train.py --config configs/imagenet/erm.yaml  # ImageNet training without 
-Reinforcements (ERM)
+python train.py --config configs/imagenet/erm.yaml  # ImageNet training without Reinforcements (ERM)
 python train.py --config configs/imagenet/kd.yaml  # Knowledge Distillation
-python train.py --config configs/imagenet/plus.yaml  # ImageNet+ training with 
-reinforcements
+python train.py --config configs/imagenet/plus.yaml  # ImageNet+ training with reinforcements
 ```
 
 Hyperparameters such as batch size for ImageNet training are optimized for 


### PR DESCRIPTION
- This PR addresses minor typographical errors in the README file. 
- The typos have been corrected for clarity and better readability. 
- The changes were made in lines where unnecessary line breaks were present, affecting the formatting of command examples.
- This update ensures that the commands are correctly presented without disruption.
## Before:
<img width="830" alt="image" src="https://github.com/apple/ml-dr/assets/67844770/737e048f-0a00-4da3-8bf8-1c0aa2fa0482">

## After:
<img width="842" alt="image" src="https://github.com/apple/ml-dr/assets/67844770/1f7ddb45-793c-4ccd-b104-ec509ff7c791">
